### PR TITLE
data.tf: pin the AMI we use by its ID

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -7,11 +7,11 @@ data "aws_availability_zones" "available" {
 # EC2
 ##############################################################################
 
-# Get the latest non-beta RHEL 8 image in AWS provided by Cloud Access.
-data "aws_ami" "rhel8_latest" {
+# Get the RHEL 8 image in AWS that we will use (provided by Cloud Access).
+data "aws_ami" "rhel8_x86" {
+  # Only images we can actually execute.
   executable_users = ["self"]
-  most_recent      = true
-  # Exclude any beta images.
+  # Restrict to RHEL8 GA images.
   name_regex = "^RHEL-8[.0-9]+_HVM-[0-9]{8}.*$"
   # Red Had Cloud Access account.
   owners = ["309956199498"]
@@ -29,6 +29,13 @@ data "aws_ami" "rhel8_latest" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
+  }
+
+  # This uniquely specifies the image, the other filters are
+  # just sanity checks.
+  filter {
+    name   = "image-id"
+    values = ["ami-0c82f7789103a1e20"]
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -13,5 +13,5 @@ output "internal_subnets" {
 }
 
 output "rhel_latest" {
-  value = "${data.aws_ami.rhel8_latest.name} (${data.aws_ami.rhel8_latest.id})"
+  value = "${data.aws_ami.rhel8_x86.name} (${data.aws_ami.rhel8_x86.id})"
 }


### PR DESCRIPTION
This makes sure the AMI cannot change behind our backs.

In general, we try with all we do to fully specify all the
variables and avoid latest/unknown versions of anything. Let's do
the same for our base images.

The AMI was queried with:
```
$ aws ec2 describe-images --owners 309956199498 --filters "Name=is-public,Values=false" "Name=name,Values=RHEL-8.3*_HVM-*" "Name=architecture,Values=x86_64" "Name=root-device-type,Values=ebs" "Name=virtualization-type,Values=hvm" --region us-east-1
```