### PR TITLE
Pause public worker fleet

### DIFF
--- a/workers-public-fleet.tf
+++ b/workers-public-fleet.tf
@@ -85,7 +85,7 @@ resource "aws_spot_fleet_request" "imagebuilder_worker_x86" {
 
   # Keep the fleet at the target_capacity at all times.
   fleet_type      = "maintain"
-  target_capacity = 1
+  target_capacity = 0
 
   # IAM role that the spot fleet service can use.
   iam_fleet_role = aws_iam_role.spot_fleet_tagging_role.arn


### PR DESCRIPTION
Set the public worker fleet size to zero until we're ready for workers.

Signed-off-by: Major Hayden <major@redhat.com>