### PR TITLE
👷 Dynamic worker counts

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,4 +4,7 @@ locals {
 
   # Ensure that staging/stable composer get the same IP address every time.
   network_interface_ip_address_index = local.workspace_name == "staging" ? 11 : 10
+
+  # Set the worker count dynamically based on the deployment environment.
+  spot_fleet_worker_count = local.workspace_name == "staging" ? 1 : 2
 }

--- a/workers-fleet-external.tf
+++ b/workers-fleet-external.tf
@@ -138,7 +138,7 @@ resource "aws_spot_fleet_request" "workers_external_x86" {
 
   # Keep the fleet at the target_capacity at all times.
   fleet_type      = "maintain"
-  target_capacity = 1
+  target_capacity = local.spot_fleet_worker_count
 
   # IAM role that the spot fleet service can use.
   iam_fleet_role = aws_iam_role.spot_fleet_tagging_role.arn


### PR DESCRIPTION
Add a local variable for a count of workers for different deployments.
Set staging to 1 and stable to 2.

Signed-off-by: Major Hayden <major@redhat.com>